### PR TITLE
Add query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Defines a request handler. Multiple calls to `on()` can be chained together.
 | --------------- | ---------------------------------------- | ----------- |
 | `method`        | `GET`                                    | HTTP method to match. Can be `*` to match any method. |
 | `path`          |                                          | HTTP request path to match. |
+| `params`        |                                          | Query Parameters |
 | `filter`        |                                          | The value is a filter function `fn(request)`: if it returns `true` the handler gets executed. |
 | `reply.status`  | `200`                                    | HTTP response status code. Can be a `number` or a synchronous function `fn(request)` that returns the response status code. |
 | `reply.headers` | `{ "content-type": "application/json" }` | HTTP response headers. `content-length` is managed by the server implementation. |
@@ -109,6 +110,20 @@ server.on({
         status:  200,
         headers: { "content-type": "application/json" },
         body:    JSON.stringify({ hello: "world" })
+    }
+});
+```
+
+or:
+```js
+server.on({
+    method: 'GET',
+    path: '/resource',
+    params: { id: '1', class: '2' },
+    reply: {
+        status:  200,
+        headers: { "content-type": "application/json" },
+        body:    JSON.stringify({ page: "resource", id: "1", class: "2" })
     }
 });
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "homepage": "https://github.com/spreaker/node-mock-http-server",
   "dependencies": {
     "connect": "^3.4.0",
+    "lodash": "^4.17.4",
     "multiparty": "^4.1.2",
-    "underscore": "^1.8.3"
+    "query-params": "^0.0.1",
+    "underscore": "^1.8.3",
+    "url-trim": "^1.0.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,9 @@ var connect     = require('connect'),
     util        = require('util'),
     _           = require('underscore'),
     multiparty  = require('multiparty');
+    lodash      = require('lodash');
+    queryParams = require('query-params');
+    urlTrim     = require('url-trim');
 
 /**
  * @param {String} host     Server host
@@ -112,8 +115,28 @@ function Server(host, port, key, cert)
             req.pathname = reqParts.pathname;
             req.query    = reqParts.query;
 
+            // Parse path.
+            if (urlTrim(handler.path) !== urlTrim(req.url)) {
+
+              return;
+            }
+
+            // Parse params.
+            if (!req.url.includes('?') && lodash.has(handler, 'params')) {
+
+              return;
+            } else if (req.url.includes('?')) {
+              const reqParams = queryParams.decode(req.url.split('?')[1]);
+              const handlerParams = lodash.get(handler, 'params', {});
+
+              if (!lodash.isEqual(reqParams, handlerParams)) {
+
+                return;
+              }
+            }
+
             // Check if we can handle the request
-            if (handled || (handler.method != "*" && req.method != handler.method.toUpperCase()) || reqParts.pathname != handler.path || (handler.filter && handler.filter(req) !== true)) {
+            if (handled || (handler.method != "*" && req.method != handler.method.toUpperCase()) || (handler.filter && handler.filter(req) !== true)) {
                 return;
             }
 


### PR DESCRIPTION
This PR implements the ability to define query parameters on the http mock server handlers, enabling the possibility to define different outputs for http requests that share the same path but have diferent query parameters.

**Example:**

```js
server.on({
  method: 'GET',
  path: '/resource',
  reply: {
      status:  200,
      headers: { "content-type": "application/json" },
      body:    JSON.stringify({ page: "resource" })
  }
});

server.on({
  method: 'GET',
  path: '/resource',
  params: { id: '1' },
  reply: {
      status:  200,
      headers: { "content-type": "application/json" },
      body:    JSON.stringify({ page: "resource", id: "1" })
  }
});
```

Output:
<p align="center"><img src="https://i.imgur.com/5CtbDDY.png"></p>

<p align="center"><img src="https://i.imgur.com/566Hiu8.png"></p>