### PR TITLE
Parse json content to req.body when content-type is application/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ server.on({
 });
 ```
 
+or (JSON is parsed when the Content-Type is 'application/json'):
+```js
+server.on({
+    method: 'POST',
+    path: '/resources',
+    filter: function (req) {
+      return _.isEqual(req.body, {
+        name: 'someName',
+        someOtherValue: 1234
+      })
+    },
+    reply: {
+        status:  201,
+        headers: { "content-type": "application/json" },
+        body: {
+          id: 987654321,
+          name: 'someName',
+          someOtherValue: 1234
+        }
+    }
+});
+```
+
 
 #### `requests(filter)`
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/spreaker/node-mock-http-server",
   "dependencies": {
+    "body-parser": "^1.18.1",
     "connect": "^3.4.0",
     "multiparty": "^4.1.2",
     "underscore": "^1.8.3"

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,8 @@ var connect     = require('connect'),
     https       = require('https'),
     util        = require('util'),
     _           = require('underscore'),
-    multiparty  = require('multiparty');
+    multiparty  = require('multiparty'),
+    bodyParser  = require('body-parser');
 
 /**
  * @param {String} host     Server host
@@ -63,6 +64,18 @@ function Server(host, port, key, cert)
 
             next();
         });
+    }
+
+    function _json(req, res, next) {
+      if (req.method !== 'POST' && req.method !== 'PUT' && req.method !== 'PATCH') {
+          return next();
+      }
+
+      if ('application/json' !== req.headers['content-type']) {
+          return next();
+      }
+
+      bodyParser.json()(req, res, next)
     }
 
     /**
@@ -181,6 +194,7 @@ function Server(host, port, key, cert)
         var connectApp = connect()
             .use(_saveRequest)
             .use(_multipart)
+            .use(_json)
             .use(_handleMockedRequest)
             .use(_handleDefaultRequest);
 


### PR DESCRIPTION
This PR adds json parsing to requests with `Content-Type: application/json`
This is useful for when you want to match on something in the body in the `filter` you define