### PR TITLE
Allow wildcard paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Defines a request handler. Multiple calls to `on()` can be chained together.
 | Option          | Default                                  | Description |
 | --------------- | ---------------------------------------- | ----------- |
 | `method`        | `GET`                                    | HTTP method to match. Can be `*` to match any method. |
-| `path`          |                                          | HTTP request path to match. |
+| `path`          |                                          | HTTP request path to match. Can be `*` to match any path (to be used in conjunction with filter to allow custom matching)|
 | `filter`        |                                          | The value is a filter function `fn(request)`: if it returns `true` the handler gets executed. |
 | `reply.status`  | `200`                                    | HTTP response status code. Can be a `number` or a synchronous function `fn(request)` that returns the response status code. |
 | `reply.headers` | `{ "content-type": "application/json" }` | HTTP response headers. `content-length` is managed by the server implementation. |

--- a/src/server.js
+++ b/src/server.js
@@ -113,7 +113,10 @@ function Server(host, port, key, cert)
             req.query    = reqParts.query;
 
             // Check if we can handle the request
-            if (handled || (handler.method != "*" && req.method != handler.method.toUpperCase()) || reqParts.pathname != handler.path || (handler.filter && handler.filter(req) !== true)) {
+            if (handled ||
+              (handler.method != "*" && req.method != handler.method.toUpperCase()) ||
+              (handler.path != "*" && reqParts.pathname != handler.path) || 
+              (handler.filter && handler.filter(req) !== true)) {
                 return;
             }
 


### PR DESCRIPTION
Wildcard paths are useful when you don't know what the exact path is going to be, for example when internal ids are involved. I figured having a wildcard and using `filter` would be better than supporting regular expressions for the path, but I can change this to allow regexes if you'd like!