### PR TITLE
A json request can have a body. 

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -67,10 +67,6 @@ function Server(host, port, key, cert)
     }
 
     function _json(req, res, next) {
-      if ('application/json' !== req.headers['content-type']) {
-          return next();
-      }
-
       bodyParser.json()(req, res, next)
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -67,10 +67,6 @@ function Server(host, port, key, cert)
     }
 
     function _json(req, res, next) {
-      if (req.method !== 'POST' && req.method !== 'PUT' && req.method !== 'PATCH') {
-          return next();
-      }
-
       if ('application/json' !== req.headers['content-type']) {
           return next();
       }


### PR DESCRIPTION
And we could need to adapt status or body of the response depending on this request body (it does not work for now).

Furthermore, bodyParser.json already check the request is a json request. It allows request with content-type set to 'application/json' as well as variations like 'application/json;charset=utf8' so I remove the obsolete code.