### PR TITLE
Allow to reset mock handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ Returns the port at which the HTTP server is listening to or `null` otherwise. T
 Returns the port at which the HTTPS server is listening to or `null` otherwise. This may be useful if you configure the HTTPS server port to `0` which means the operating system will assign an arbitrary unused port.
 
 
+#### `resetHandlers()`
+
+Clears all request handlers that were previously set using `on()` method.
+
+
 
 ## Contribute
 

--- a/src/server.js
+++ b/src/server.js
@@ -274,6 +274,10 @@ function Server(host, port, key, cert)
         return this;
     };
 
+    this.resetHandlers = function() {
+        handlers = [];
+    };
+
     /**
      * Returns an array containing all requests received. If `filter` is defined,
      * filters the requests by:
@@ -311,12 +315,13 @@ function Server(host, port, key, cert)
 
 function ServerVoid() {
 
-    this.on          = function() {};
-    this.start       = function(callback) { callback(); };
-    this.stop        = function(callback) { callback(); };
-    this.requests    = function() { return []; };
-    this.connections = function() { return []; };
-    this.getPort     = function() { return null; };
+    this.on            = function() {};
+    this.start         = function(callback) { callback(); };
+    this.stop          = function(callback) { callback(); };
+    this.requests      = function() { return []; };
+    this.connections   = function() { return []; };
+    this.getPort       = function() { return null; };
+    this.resetHandlers = function() {};
 }
 
 /**
@@ -363,6 +368,11 @@ function ServerMock(httpConfig, httpsConfig)
 
     this.getHttpsPort = function() {
         return httpsServerMock.getPort();
+    }
+
+    this.resetHandlers = function() {
+        httpServerMock.resetHandlers();
+        httpsServerMock.resetHandlers();
     }
 }
 


### PR DESCRIPTION
Hello,
I wanted a way to reset the the http-server-mock handlers without having to restart or recreate the mock