### PR TITLE
Add text bodyParser middleware

### DIFF
--- a/spec/helpers/client.js
+++ b/spec/helpers/client.js
@@ -11,9 +11,9 @@ const http = require("http");
  * @param  {String} path
  * @return {Promise}
  */
-module.exports.request = (host, port, method, path) => {
+module.exports.request = (host, port, method, path, headers, body) => {
     return new Promise((resolve, reject) => {
-        const req = http.request({ host: host, port: port, method: method, path: path }, (res) => {
+        const req = http.request({ host: host, port: port, method: method, headers: headers, path: path }, (res) => {
             res.body = "";
 
             res.on("data", (chunk) => {
@@ -28,6 +28,10 @@ module.exports.request = (host, port, method, path) => {
         req.on("error", (err) => {
             reject(err);
         });
+
+        if (body) {
+            req.write(body);
+        }
 
         req.end();
     });

--- a/spec/http_server_spec.js
+++ b/spec/http_server_spec.js
@@ -72,5 +72,24 @@ describe("ServerMock", () => {
             expect(res.headers["content-type"]).toBe("plain/text");
             expect(res.body).toBe("Not Found");
         });
+
+        it("should get a text plain body when content-type is text/plain", async () => {
+            server.on({
+                method: "POST",
+                path: "/resource",
+                reply: {
+                    status: function(req) {
+                        if (req.body !== "Hello world\nThis is a text") {
+                            return 403;
+                        }
+                        return 200;
+                    }
+                }
+            });
+
+            const res = await client.request("localhost", server.getHttpPort(), "POST", "/resource", { "Content-Type": "text/plain" }, "Hello world\nThis is a text");
+
+            expect(res.statusCode).toBe(200);
+        });
     });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -197,6 +197,7 @@ function Server(host, port, key, cert)
             .use(_saveRequest)
             .use(_multipart)
             .use(bodyParser.json())
+            .use(bodyParser.text())
             .use(bodyParser.urlencoded({extended: true}))
             .use(_handleMockedRequest)
             .use(_handleDefaultRequest);


### PR DESCRIPTION
I'm having a use case in which an external library is sending a `POST` request using `Content-Type: text-plain` and I would like to check the content of the request body to verify my application is working.

To do so, I added the `bodyParser.text()` middleware which by default will be executed only when the `Content-Type` header is `text-plain`. This allows me to get the request body and compare with my expectations.

I've added some tests as well