### PR TITLE
fix requests filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ server.on({
 
 #### `requests(filter)`
 
-Returns an array containing all requests received. If `filter` is defined, it allows to filter requests by `method` and/or `path`.
+Returns an array containing all requests received. If `filter` is defined, it allows to filter requests by `method`, `path`, or both.
 
 | Filter          | Description |
 | --------------- | ----------- |

--- a/src/server.js
+++ b/src/server.js
@@ -291,7 +291,10 @@ function Server(host, port, key, cert)
     this.requests = function(filter) {
         return _(requests).filter(function(req) {
             var reqParts = url.parse(req.url, true);
-            return !filter || filter.method === req.method || filter.path === reqParts.pathname;
+            const methodMatch = !filter || !filter.method || filter.method === req.method;
+            const pathMatch = !filter || !filter.path || filter.path === reqParts.pathname;
+
+            return methodMatch && pathMatch;
         });
     };
 


### PR DESCRIPTION
Filter requests by method **and** path if both specified. Currently filter uses **or** operator, which seems very counter-intuitive to me.