### PR TITLE
feat(typing): facilitating generation of type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,6 +319,12 @@
         "mime-types": "~2.1.18"
       }
     },
+    "typescript": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.4.1",
   "description": "Controllable HTTP Server Mock for your functional tests",
   "main": "index.js",
+  "typings": "typings/index",
   "scripts": {
+    "prepublishOnly": "tsc index.js --allowjs --declaration --emitDeclarationOnly --declarationDir typings",
     "test": "./node_modules/.bin/jasmine"
   },
   "repository": {
@@ -23,6 +25,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "jasmine": "^3.3.1"
+    "jasmine": "^3.3.1",
+    "typescript": "^3.7.2"
   }
 }


### PR DESCRIPTION
Thanks for this cool package. Would you be interested in automatically generating the type definitions for this package? With TS 3.7.x it can be automated (refer: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#--declaration-and--allowjs).