### PR TITLE
Add a cleanRequests() function to discard previous requests received by ServerMock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode
 node_modules

--- a/README.md
+++ b/README.md
@@ -207,13 +207,16 @@ Returns the port at which the HTTP server is listening to or `null` otherwise. T
 
 Returns the port at which the HTTPS server is listening to or `null` otherwise. This may be useful if you configure the HTTPS server port to `0` which means the operating system will assign an arbitrary unused port.
 
+#### `reset()`
+
+Clears request handlers and requests received by the HTTP server.
 
 #### `resetHandlers()`
 
 Clears all request handlers that were previously set using `on()` method.
 
 
-#### `cleanRequests()`
+#### `resetRequests()`
 
 Clears all requests received by the HTTP server.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ Returns the port at which the HTTPS server is listening to or `null` otherwise. 
 Clears all request handlers that were previously set using `on()` method.
 
 
+#### `cleanRequests()`
+
+Clears all requests received by the HTTP server.
+
+
 
 ## Contribute
 

--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,8 @@ function Server(host, port, key, cert)
         address     = null,
         handlers    = [],
         requests    = [],
-        connections = [];
+        connections = [],
+        self = this;
 
     function _saveRequest(req, res, next) {
         requests.push(req);
@@ -277,7 +278,12 @@ function Server(host, port, key, cert)
 
     this.resetHandlers = function() {
         handlers = [];
+        self.cleanRequests();
     };
+
+    this.cleanRequests = function() {
+        requests = [];
+    }
 
     /**
      * Returns an array containing all requests received. If `filter` is defined,
@@ -326,6 +332,7 @@ function ServerVoid() {
     this.connections   = function() { return []; };
     this.getPort       = function() { return null; };
     this.resetHandlers = function() {};
+    this.cleanRequests = function() {};
 }
 
 /**
@@ -377,6 +384,11 @@ function ServerMock(httpConfig, httpsConfig)
     this.resetHandlers = function() {
         httpServerMock.resetHandlers();
         httpsServerMock.resetHandlers();
+    }
+
+    this.cleanRequests = function() {
+        httpServerMock.cleanRequests();
+        httpsServerMock.cleanRequests();
     }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -276,12 +276,25 @@ function Server(host, port, key, cert)
         return this;
     };
 
+    /**
+     * Clears request handlers and requests received by the HTTP server.
+     */
+    this.reset = function() {
+        self.resetHandlers();
+        self.resetRequests();
+    }
+
+    /**
+     * Clears all request handlers that were previously set using `on()` method.
+     */
     this.resetHandlers = function() {
         handlers = [];
-        self.cleanRequests();
     };
 
-    this.cleanRequests = function() {
+    /**
+     * Clears all requests received by the HTTP server.
+     */
+    this.resetRequests = function() {
         requests = [];
     }
 
@@ -331,8 +344,9 @@ function ServerVoid() {
     this.requests      = function() { return []; };
     this.connections   = function() { return []; };
     this.getPort       = function() { return null; };
+    this.reset         = function() {};
     this.resetHandlers = function() {};
-    this.cleanRequests = function() {};
+    this.resetRequests = function() {};
 }
 
 /**
@@ -381,14 +395,19 @@ function ServerMock(httpConfig, httpsConfig)
         return httpsServerMock.getPort();
     }
 
+    this.reset = function() {
+        httpServerMock.reset();
+        httpsServerMock.reset();
+    }
+
     this.resetHandlers = function() {
         httpServerMock.resetHandlers();
         httpsServerMock.resetHandlers();
     }
 
-    this.cleanRequests = function() {
-        httpServerMock.cleanRequests();
-        httpsServerMock.cleanRequests();
+    this.resetRequests = function() {
+        httpServerMock.resetRequests();
+        httpsServerMock.resetRequests();
     }
 }
 


### PR DESCRIPTION
In order to reuse handlers in unit tests without loading a new ServerMock, this function clean the requests stored in ServerMock.

This function is also invoked in `resetHandlers()`.