### PR TITLE
Handled weird mime types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+#### 1.4.3 (2021-05-28)
+ * Fallback to `text/plain` body parse in the request when format is not handled.
 #### 1.4.1 (2019-10-07)
  * Fixed `requests()` filtering: multiple conditions are now in **and** instead of **or** (PR [#21](https://github.com/spreaker/node-mock-http-server/pull/21) - thanks to [danroshko](https://github.com/danroshko))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-http-server",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-http-server",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Controllable HTTP Server Mock for your functional tests",
   "main": "index.js",
   "scripts": {

--- a/spec/http_server_spec.js
+++ b/spec/http_server_spec.js
@@ -91,6 +91,25 @@ describe("ServerMock", () => {
 
             expect(res.statusCode).toBe(200);
         });
+
+        it("should get a text plain body as a fallback", async () => {
+            server.on({
+                method: "POST",
+                path: "/resource",
+                reply: {
+                    status: function(req) {
+                        if (req.body !== "{}\n{}\n") {
+                            return 403;
+                        }
+                        return 200;
+                    }
+                }
+            });
+
+            const res = await client.request("localhost", server.getHttpPort(), "POST", "/resource",  { "Content-Type": "application/x-ndjson" }, "{}\n{}\n");
+
+            expect(res.statusCode).toBe(200);
+        });
     });
 
     

--- a/src/server.js
+++ b/src/server.js
@@ -200,6 +200,7 @@ function Server(host, port, key, cert)
             .use(bodyParser.json())
             .use(bodyParser.text())
             .use(bodyParser.urlencoded({extended: true}))
+            .use(bodyParser.text({type: "*/*"}))
             .use(_handleMockedRequest)
             .use(_handleDefaultRequest);
 


### PR DESCRIPTION
Fallback to `text/plain` body parse in the request when format is not handled.

Currently if the request body is for example `application/x-ndjson` nothing is parsed in the mock server. This PR solves it.