### PR TITLE
Bettere handling the fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+#### 1.4.4 (2021-06-08)
+ * Improve fallback to `text/plain` body parse in the request when format is not handled.
 #### 1.4.3 (2021-05-28)
  * Fallback to `text/plain` body parse in the request when format is not handled.
 #### 1.4.1 (2019-10-07)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-http-server",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Controllable HTTP Server Mock for your functional tests",
   "main": "index.js",
   "scripts": {

--- a/spec/http_server_spec.js
+++ b/spec/http_server_spec.js
@@ -110,6 +110,25 @@ describe("ServerMock", () => {
 
             expect(res.statusCode).toBe(200);
         });
+
+        it("should get a text plain body as a fallback when no content type is passed", async () => {
+            server.on({
+                method: "POST",
+                path: "/resource",
+                reply: {
+                    status: function(req) {
+                        if (req.body !== "{}\n{}\n") {
+                            return 403;
+                        }
+                        return 200;
+                    }
+                }
+            });
+
+            const res = await client.request("localhost", server.getHttpPort(), "POST", "/resource",  {}, "{}\n{}\n");
+
+            expect(res.statusCode).toBe(200);
+        });
     });
 
     

--- a/src/server.js
+++ b/src/server.js
@@ -200,7 +200,7 @@ function Server(host, port, key, cert)
             .use(bodyParser.json())
             .use(bodyParser.text())
             .use(bodyParser.urlencoded({extended: true}))
-            .use(bodyParser.text({type: "*/*"}))
+            .use(bodyParser.text({type: function() { return true; }}))
             .use(_handleMockedRequest)
             .use(_handleDefaultRequest);
 


### PR DESCRIPTION
This is an improvement over this PR:

https://github.com/spreaker/node-mock-http-server/pull/31

We now handle the case where no content type is passed at all too.