### PR TITLE
refactor!: update code and remove underscore dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./src/server");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-http-server",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -318,11 +318,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
-    },
-    "underscore": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",
-      "integrity": "sha1-MduzFM/MiPFpzTaS2RSdgaAKc+Q="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "body-parser": "^1.18.1",
     "connect": "^3.4.0",
-    "multiparty": "^4.1.2",
-    "underscore": "^1.8.3"
+    "multiparty": "^4.1.2"
   },
   "devDependencies": {
     "jasmine": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "mock-http-server",
   "version": "1.4.5",
   "description": "Controllable HTTP Server Mock for your functional tests",
-  "main": "index.js",
+  "main": "src/server.js",
   "scripts": {
-    "test": "./node_modules/.bin/jasmine"
+    "test": "jasmine"
   },
   "repository": {
     "type": "git",

--- a/spec/helpers/client.js
+++ b/spec/helpers/client.js
@@ -5,11 +5,11 @@ const http = require("http");
  * Sends an HTTP request to the server and returns a Promise which resolve
  * with the HTTP response containing the body too.
  *
- * @param  {String} host
- * @param  {String} port
- * @param  {String} method
- * @param  {String} path
- * @return {Promise}
+ * @param  {string} host
+ * @param  {number} port
+ * @param  {string} method
+ * @param  {string} path
+ * @return {Promise<{body: string;}>}
  */
 module.exports.request = (host, port, method, path, headers, body) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This change updates the code in the following ways:

1. Remove `var` usage and replace with `let`/`const` where appropriate
2. Removes the dependency on underscore and replaces the helper methods with native code
3. package.json is slightly refactored to set the entry point as `src/server.js` instead of `index.js` - as this isn't really needed

I'd consider this potentially to be a breaking change, though I was surprised to see it still maintains Node 8+ support.